### PR TITLE
Implement Reminder Sharing Feature in Chat Module

### DIFF
--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -1,5 +1,5 @@
 const Message = require('../models/chat.js');
-
+const MedicationReminder = require('../models/medicationReminder.js')
 exports.getChatHistory = async (req, res) => {
     try {
       const { senderId, receiverId } = req.params;
@@ -57,6 +57,15 @@ exports.saveMessage = async (req, res) => {
     } catch (error) {
       console.error("Error sharing location:", error);
       res.status(500).json({ message: "Failed to share location.", error });
+    }
+  };
+  
+
+  exports.shareReminders = async (req, res) => {
+    try {
+      
+    } catch (error) {
+      
     }
   };
   

--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -63,7 +63,7 @@ exports.saveMessage = async (req, res) => {
 
   exports.shareReminders = async (req, res) => {
     try {
-      
+      const { senderId, receiverId, reminderIds } = req.body;
     } catch (error) {
       console.error('Error Sharing Remiders : ', error);
       res.status(500).json({ message: 'Error sharing reminders', error });

--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -79,6 +79,14 @@ exports.saveMessage = async (req, res) => {
           `Title: ${reminder.title}\nDetails: ${reminder.details}\nTime: ${reminder.reminderTime}`
       )
       .join('\n\n');
+
+      const message = new Message({
+        sender: senderId,
+        receiver: receiverId,
+        text: `Shared Medication Reminders:\n\n${reminderText}`, // Include reminders in text
+      });
+  
+      await message.save();
     } catch (error) {
       console.error('Error Sharing Remiders : ', error);
       res.status(500).json({ message: 'Error sharing reminders', error });

--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -73,6 +73,12 @@ exports.saveMessage = async (req, res) => {
         return res.status(404).json({ message: 'No valid reminders found to share' });
       }
   
+      const reminderText = reminders
+      .map(
+        (reminder) =>
+          `Title: ${reminder.title}\nDetails: ${reminder.details}\nTime: ${reminder.reminderTime}`
+      )
+      .join('\n\n');
     } catch (error) {
       console.error('Error Sharing Remiders : ', error);
       res.status(500).json({ message: 'Error sharing reminders', error });

--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -66,6 +66,7 @@ exports.saveMessage = async (req, res) => {
       
     } catch (error) {
       console.error('Error Sharing Remiders : ', error);
+      res.status(500).json({ message: 'Error sharing reminders', error });
     }
   };
   

--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -65,7 +65,7 @@ exports.saveMessage = async (req, res) => {
     try {
       
     } catch (error) {
-      
+      console.error('Error Sharing Remiders : ', error);
     }
   };
   

--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -64,6 +64,15 @@ exports.saveMessage = async (req, res) => {
   exports.shareReminders = async (req, res) => {
     try {
       const { senderId, receiverId, reminderIds } = req.body;
+
+      const reminders = await MedicationReminder.find({
+        _id: { $in: reminderIds },
+      });
+  
+      if (reminders.length === 0) {
+        return res.status(404).json({ message: 'No valid reminders found to share' });
+      }
+  
     } catch (error) {
       console.error('Error Sharing Remiders : ', error);
       res.status(500).json({ message: 'Error sharing reminders', error });

--- a/backend/src/controllers/chat.controllers.js
+++ b/backend/src/controllers/chat.controllers.js
@@ -87,6 +87,12 @@ exports.saveMessage = async (req, res) => {
       });
   
       await message.save();
+
+      res.status(201).json({
+        message: 'Reminders shared successfully',
+        data: message,
+      });
+      
     } catch (error) {
       console.error('Error Sharing Remiders : ', error);
       res.status(500).json({ message: 'Error sharing reminders', error });

--- a/backend/src/routes/chat.router.js
+++ b/backend/src/routes/chat.router.js
@@ -13,5 +13,7 @@ router.post('/send', authenticateToken, chatController.saveMessage);
 
 router.post('/location', authenticateToken, chatController.shareLocation);
 
+router.post('/shareReminders', authenticateToken, chatController.shareReminders);
+
 
 module.exports = router;


### PR DESCRIPTION
# Implement Reminder Sharing Feature in Chat Module

## **Description**
This pull request introduces the functionality to share medication reminders between users in the chat module. Users can select specific reminders to share, which are formatted and sent as part of a chat message.

## **Changes**
- **Controller :** Added `shareReminders` function in `chat.controllers.js` to handle reminder sharing.
  - **Logic :**
    - Fetch reminders by their IDs from the `MedicationReminder` collection.
    - Handle cases where no valid reminders are found, returning a 404 response.
    - Format reminder details into a readable text message.
    - Save the formatted message in the `Message` collection with sender and receiver details.
  - **Error Handling :** Log errors and send appropriate failure responses for invalid or failed operations.
  - **Response :** Send a success response with the saved message data upon successful sharing.

## **Testing**
- **Valid Scenarios :**
  - Share reminders with valid `senderId`, `receiverId`, and `reminderIds`.
  - Confirm that reminders are properly formatted and saved as messages.
  - Verify success responses with the correct message data.
- **Error Scenarios :**
  - Test with invalid or nonexistent `reminderIds` to ensure a 404 response.
  - Handle unexpected server errors gracefully, logging details for debugging.

## **Future Improvements**
- Implement reminder sharing in bulk or group chat scenarios.
- Add validation for `reminderIds` to ensure all IDs are valid and unique.
- Support multimedia sharing (e.g., reminder images or files).

